### PR TITLE
[backend][1.4] configure local H2 profile

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:file:./data/keyboard-trainer;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,15 +1,8 @@
 spring:
   application:
     name: keyboardTrainer
-  datasource:
-    url: jdbc:h2:file:./data/keyboard-trainer;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+  profiles:
+    default: local
 
 server:
   port: 8080

--- a/src/test/java/com/sqltrainer/app/LocalDataSourceTest.java
+++ b/src/test/java/com/sqltrainer/app/LocalDataSourceTest.java
@@ -1,0 +1,36 @@
+package com.sqltrainer.app;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+@SpringBootTest
+@ActiveProfiles("local")
+class LocalDataSourceTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldUseH2ForLocalProfile() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            String databaseProduct = connection.getMetaData().getDatabaseProductName();
+            if (!"H2".equals(databaseProduct)) {
+                throw new AssertionError("Expected H2 datasource for local profile");
+            }
+        }
+
+        Integer probeResult = jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+        if (!Integer.valueOf(1).equals(probeResult)) {
+            throw new AssertionError("Expected datasource probe query to return 1");
+        }
+    }
+}


### PR DESCRIPTION
Closes #9

## Summary
- move H2 datasource settings into an explicit local profile
- make local the default Spring profile for developer startup
- verify the local datasource through an integration smoke test
